### PR TITLE
Ignore ifspeeds below 0 in LinuxLocal

### DIFF
--- a/plugins-scripts/Classes/Server/LinuxLocal.pm
+++ b/plugins-scripts/Classes/Server/LinuxLocal.pm
@@ -34,7 +34,7 @@ sub init {
     foreach (glob "/sys/class/net/*") {
       my $name = $_;
       $name =~ s/.*\///g;
-      my $tmp_speed = (-f "/sys/class/net/$name/speed" ? do { local (@ARGV, $/) = "/sys/class/net/$name/speed"; my $x = <>; close ARGV; $x; } : undef);
+      my $tmp_speed = (-f "/sys/class/net/$name/speed" ? do { local (@ARGV, $/) = "/sys/class/net/$name/speed"; my $x = <>; close ARGV; (defined $x && $x >= 0) ? $x : undef; } : undef);
       $max_speed = $tmp_speed if defined $tmp_speed && $tmp_speed > $max_speed;
       next if ! $self->filter_name($name);
       *SAVEERR = *STDERR;


### PR DESCRIPTION
In certain configurations when running virtualized (kvm), some distributions (at least Debian 9 and 10) report `-1` in `/sys/class/net/*/speed` if running virtualized (kvm). This leads to miscalculations e.g. `ifSpeed: -1048576` `(-1*1024*1024)`. This patch will ignore ifSpeeds less than 0. Percentages won't get calculated because there is no maximum bandwidth set (--ifspeed).